### PR TITLE
Tidy up the backwards pass of type 1

### DIFF
--- a/pytorch_finufft/functional.py
+++ b/pytorch_finufft/functional.py
@@ -815,12 +815,15 @@ class finufft_type1(torch.autograd.Function):
             # wrt points
             start_points = -(torch.tensor(grad_output.shape, device=device) // 2)
             end_points = start_points + torch.tensor(grad_output.shape, device=device)
-            coord_ramps = torch.cartesian_prod(
-                *(
-                    torch.arange(start, end, device=device)
-                    for start, end in zip(start_points, end_points)
+            coord_ramps = torch.stack(
+                torch.meshgrid(
+                    *(
+                        torch.arange(start, end, device=device)
+                        for start, end in zip(start_points, end_points)
+                    ),
+                    indexing="ij",
                 )
-            ).to(device)
+            )
 
             # we can't batch in 1d case so we squeeze and fix up the ouput later
             ramped_grad_output = (


### PR DESCRIPTION
1. Clean up something where we were doing an fftshift, multiply, and ifftshift to just do 1 fftshift of the thing we were multiplying by
2. Remove the need to call FINUFFT multiple times in the points derivative by using the built-in batching functionality
3. Remove the numpy logic creating the ramp and replace it with a torch-native solution