### PR TITLE
[WIP] type 2 finufft consolidated

### DIFF
--- a/pytorch_finufft/functional.py
+++ b/pytorch_finufft/functional.py
@@ -902,7 +902,7 @@ class finufft_type2(torch.autograd.Function):
             print("In-place results are not yet implemented")
 
         # TODO -- extend checks to 2d
-        err._type2_checks(points, targets)
+        checks._type2_checks(points, targets)
 
         finufftkwargs = {k: v for k, v in finufftkwargs.items()}
         _mode_ordering = finufftkwargs.pop("modeord", 1)

--- a/pytorch_finufft/functional.py
+++ b/pytorch_finufft/functional.py
@@ -916,8 +916,9 @@ class finufft_type2(torch.autograd.Function):
                 )
             _mode_ordering = 0
 
+        ndim = points.shape[0]
         if _mode_ordering == 1:
-            targets = torch.fft.fftshift(targets, dim=(-2, -1))
+            targets = torch.fft.fftshift(targets, dim=tuple(range(-ndim, 0)))
 
 
         ctx.isign = _i_sign
@@ -927,15 +928,16 @@ class finufft_type2(torch.autograd.Function):
 
         ctx.save_for_backward(points, targets)
 
-        finufft_out = finufft.nufft2d2(
+        nufft_func = get_nufft_func(ndim, 2, points.device.type)
+
+        finufft_out = nufft_func(
             *points.data.numpy(),
             targets.data.numpy(),
-            #modeord=_mode_ordering,
             isign=_i_sign,
             **finufftkwargs,
         )
 
-        return torch.from_numpy(finufft_out)
+        return finufft_out
 
     @staticmethod
     def backward(

--- a/pytorch_finufft/functional.py
+++ b/pytorch_finufft/functional.py
@@ -1001,14 +1001,14 @@ class finufft_type2(torch.autograd.Function):
 
             grad_points = nufft_func(
                     *points,
-                    ramped_targets,
+                    ramped_targets.squeeze(),
                     isign=_i_sign,
                     #modeord=_mode_ordering,
                     **finufftkwargs,
                 ).conj()  # Currently don't really get why this is hard to replace with a flipped isign
 
             grad_points = grad_points * grad_output
-            grad_points = grad_points.real
+            grad_points = torch.atleast_2d(grad_points.real)
 
         if ctx.needs_input_grad[1]:
             # wrt. targets

--- a/tests/test_1d/test_backward_1d.py
+++ b/tests/test_1d/test_backward_1d.py
@@ -212,7 +212,7 @@ def test_t2_backward_CPU_points(
 @pytest.mark.parametrize("modifier", length_modifiers)
 @pytest.mark.parametrize("fftshift", [False, True])
 @pytest.mark.parametrize("isign", [-1, 1])
-def test_t2_backward_CPU_values(
+def test_t2_backward_cuda_values(
     N: int, modifier: int, fftshift: bool, isign: int
 ) -> None:
     check_t2_backward(N, modifier, fftshift, isign, "cuda", False)
@@ -221,7 +221,7 @@ def test_t2_backward_CPU_values(
 @pytest.mark.parametrize("modifier", length_modifiers)
 @pytest.mark.parametrize("fftshift", [False, True])
 @pytest.mark.parametrize("isign", [-1, 1])
-def test_t2_backward_CPU_points(
+def test_t2_backward_cuda_points(
     N: int, modifier: int, fftshift: bool, isign: int
 ) -> None:
     check_t2_backward(N, modifier, fftshift, isign, "cuda", True)

--- a/tests/test_1d/test_backward_1d.py
+++ b/tests/test_1d/test_backward_1d.py
@@ -161,3 +161,50 @@ def test_t2_backward_CPU_points(
     inputs = (points, targets)
 
     assert gradcheck(apply_finufft1d2(fftshift, isign), inputs, eps=1e-8, atol=1e-5 * N)
+
+
+def check_t2_backward(
+    N: int,
+    modifier: int,
+    fftshift: bool,
+    isign: int,
+    device: str,
+    points_or_targets: bool,
+) -> None:
+    points = torch.rand((1, N + modifier), dtype=torch.float64).to(device) * 2 * np.pi
+    targets = torch.randn(N, dtype=torch.complex128).to(device)
+
+    points.requires_grad = points_or_targets
+    targets.requires_grad = not points_or_targets
+
+    inputs = (points, targets)
+
+    def func(points, targets):
+        return pytorch_finufft.functional.finufft_type2.apply(
+            points,
+            targets,
+            None,
+            dict(modeord=int(not fftshift), isign=isign),
+        )
+
+    assert gradcheck(func, inputs, atol=1.5e-4 * N)
+
+
+@pytest.mark.parametrize("N", Ns)
+@pytest.mark.parametrize("modifier", length_modifiers)
+@pytest.mark.parametrize("fftshift", [False, True])
+@pytest.mark.parametrize("isign", [-1, 1])
+def test_t2_backward_CPU_values(
+    N: int, modifier: int, fftshift: bool, isign: int
+) -> None:
+    check_t2_backward(N, modifier, fftshift, isign, "cpu", False)
+
+@pytest.mark.parametrize("N", Ns)
+@pytest.mark.parametrize("modifier", length_modifiers)
+@pytest.mark.parametrize("fftshift", [False, True])
+@pytest.mark.parametrize("isign", [-1, 1])
+def test_t2_backward_CPU_points(
+    N: int, modifier: int, fftshift: bool, isign: int
+) -> None:
+    check_t2_backward(N, modifier, fftshift, isign, "cpu", True)
+

--- a/tests/test_1d/test_backward_1d.py
+++ b/tests/test_1d/test_backward_1d.py
@@ -187,7 +187,7 @@ def check_t2_backward(
             dict(modeord=int(not fftshift), isign=isign),
         )
 
-    assert gradcheck(func, inputs, atol=1.5e-4 * N)
+    assert gradcheck(func, inputs, atol=5e-3 * N)
 
 
 @pytest.mark.parametrize("N", Ns)
@@ -207,4 +207,22 @@ def test_t2_backward_CPU_points(
     N: int, modifier: int, fftshift: bool, isign: int
 ) -> None:
     check_t2_backward(N, modifier, fftshift, isign, "cpu", True)
+
+@pytest.mark.parametrize("N", Ns)
+@pytest.mark.parametrize("modifier", length_modifiers)
+@pytest.mark.parametrize("fftshift", [False, True])
+@pytest.mark.parametrize("isign", [-1, 1])
+def test_t2_backward_CPU_values(
+    N: int, modifier: int, fftshift: bool, isign: int
+) -> None:
+    check_t2_backward(N, modifier, fftshift, isign, "cuda", False)
+
+@pytest.mark.parametrize("N", Ns)
+@pytest.mark.parametrize("modifier", length_modifiers)
+@pytest.mark.parametrize("fftshift", [False, True])
+@pytest.mark.parametrize("isign", [-1, 1])
+def test_t2_backward_CPU_points(
+    N: int, modifier: int, fftshift: bool, isign: int
+) -> None:
+    check_t2_backward(N, modifier, fftshift, isign, "cuda", True)
 

--- a/tests/test_2d/test_backward_2d.py
+++ b/tests/test_2d/test_backward_2d.py
@@ -254,7 +254,7 @@ def test_t2_backward_CPU_points(
 @pytest.mark.parametrize("modifier", length_modifiers)
 @pytest.mark.parametrize("fftshift", [False, True])
 @pytest.mark.parametrize("isign", [-1, 1])
-def test_t2_backward_CPU_values(
+def test_t2_backward_cuda_values(
     N: int, modifier: int, fftshift: bool, isign: int
 ) -> None:
     check_t2_backward(N, modifier, fftshift, isign, "cuda", False)
@@ -263,7 +263,7 @@ def test_t2_backward_CPU_values(
 @pytest.mark.parametrize("modifier", length_modifiers)
 @pytest.mark.parametrize("fftshift", [False, True])
 @pytest.mark.parametrize("isign", [-1, 1])
-def test_t2_backward_CPU_points(
+def test_t2_backward_cuda_points(
     N: int, modifier: int, fftshift: bool, isign: int
 ) -> None:
     check_t2_backward(N, modifier, fftshift, isign, "cuda", True)

--- a/tests/test_2d/test_backward_2d.py
+++ b/tests/test_2d/test_backward_2d.py
@@ -250,3 +250,21 @@ def test_t2_backward_CPU_points(
 ) -> None:
     check_t2_backward(N, modifier, fftshift, isign, "cpu", True)
 
+@pytest.mark.parametrize("N", Ns)
+@pytest.mark.parametrize("modifier", length_modifiers)
+@pytest.mark.parametrize("fftshift", [False, True])
+@pytest.mark.parametrize("isign", [-1, 1])
+def test_t2_backward_CPU_values(
+    N: int, modifier: int, fftshift: bool, isign: int
+) -> None:
+    check_t2_backward(N, modifier, fftshift, isign, "cuda", False)
+
+@pytest.mark.parametrize("N", Ns)
+@pytest.mark.parametrize("modifier", length_modifiers)
+@pytest.mark.parametrize("fftshift", [False, True])
+@pytest.mark.parametrize("isign", [-1, 1])
+def test_t2_backward_CPU_points(
+    N: int, modifier: int, fftshift: bool, isign: int
+) -> None:
+    check_t2_backward(N, modifier, fftshift, isign, "cuda", True)
+

--- a/tests/test_2d/test_backward_2d.py
+++ b/tests/test_2d/test_backward_2d.py
@@ -202,3 +202,51 @@ def test_t2_backward_CPU_points_y(
     inputs = (points_x, points_y, targets)
 
     assert gradcheck(apply_finufft2d2(fftshift, isign), inputs)
+
+
+
+def check_t2_backward(
+    N: int,
+    modifier: int,
+    fftshift: bool,
+    isign: int,
+    device: str,
+    points_or_targets: bool,
+) -> None:
+    points = torch.rand((2, N + modifier), dtype=torch.float64).to(device) * 2 * np.pi
+    targets = torch.randn(N, N, dtype=torch.complex128).to(device)
+
+    points.requires_grad = points_or_targets
+    targets.requires_grad = not points_or_targets
+
+    inputs = (points, targets)
+
+    def func(points, targets):
+        return pytorch_finufft.functional.finufft_type2.apply(
+            points,
+            targets,
+            None,
+            dict(modeord=int(not fftshift), isign=isign),
+        )
+
+    assert gradcheck(func, inputs, atol=1e-5 * N)
+
+
+@pytest.mark.parametrize("N", Ns)
+@pytest.mark.parametrize("modifier", length_modifiers)
+@pytest.mark.parametrize("fftshift", [False, True])
+@pytest.mark.parametrize("isign", [-1, 1])
+def test_t2_backward_CPU_values(
+    N: int, modifier: int, fftshift: bool, isign: int
+) -> None:
+    check_t2_backward(N, modifier, fftshift, isign, "cpu", False)
+
+@pytest.mark.parametrize("N", Ns)
+@pytest.mark.parametrize("modifier", length_modifiers)
+@pytest.mark.parametrize("fftshift", [False, True])
+@pytest.mark.parametrize("isign", [-1, 1])
+def test_t2_backward_CPU_points(
+    N: int, modifier: int, fftshift: bool, isign: int
+) -> None:
+    check_t2_backward(N, modifier, fftshift, isign, "cpu", True)
+

--- a/tests/test_2d/test_forward_2d.py
+++ b/tests/test_2d/test_forward_2d.py
@@ -114,7 +114,8 @@ def test_2d_t2_forward_CPU(N: int) -> None:
 
 
 @pytest.mark.parametrize("N", Ns)
-def test_t2_forward_CPU(N: int) -> None:
+@pytest.mark.parametrize("fftshift", [False, True])
+def test_t2_forward_CPU(N: int, fftshift: bool) -> None:
     """
     Tests against implementations of the FFT by setting up a uniform grid
     over which to call FINUFFT through the API.
@@ -131,9 +132,14 @@ def test_t2_forward_CPU(N: int) -> None:
     finufft_out = pytorch_finufft.functional.finufft_type2.apply(
         points,
         targets,
+        None,
+        {'modeord': int(not fftshift)},
     )
 
-    against_torch = torch.fft.fft2(targets)
+    if fftshift:
+        against_torch = torch.fft.fft2(torch.fft.ifftshift(targets))
+    else:
+        against_torch = torch.fft.fft2(targets)
 
     abs_errors = torch.abs(finufft_out - against_torch.ravel())
     l_inf_error = abs_errors.max()

--- a/tests/test_2d/test_forward_2d.py
+++ b/tests/test_2d/test_forward_2d.py
@@ -9,6 +9,7 @@ torch.manual_seed(0)
 
 # Case generation
 Ns = [
+    3,
     10,
     15,
     75,
@@ -110,3 +111,36 @@ def test_2d_t2_forward_CPU(N: int) -> None:
     assert l_inf_error < 1e-5 * N
     assert l_2_error < 1e-5 * N**2
     assert l_1_error < 1e-5 * N**3
+
+
+@pytest.mark.parametrize("N", Ns)
+def test_t2_forward_CPU(N: int) -> None:
+    """
+    Tests against implementations of the FFT by setting up a uniform grid
+    over which to call FINUFFT through the API.
+    """
+    g = np.mgrid[:N, :N] * 2 * np.pi / N
+    points = torch.from_numpy(g.reshape(2, -1))
+
+    targets = torch.randn(*g[0].shape, dtype=torch.complex128)
+
+    print("N is " + str(N))
+    print("shape of points is " + str(points.shape))
+    print("shape of targets is " + str(targets.shape))
+
+    finufft_out = pytorch_finufft.functional.finufft_type2.apply(
+        points,
+        targets,
+    )
+
+    against_torch = torch.fft.fft2(targets)
+
+    abs_errors = torch.abs(finufft_out - against_torch.ravel())
+    l_inf_error = abs_errors.max()
+    l_2_error = torch.sqrt(torch.sum(abs_errors**2))
+    l_1_error = torch.sum(abs_errors)
+
+    assert l_inf_error < 4.5e-5 * N
+    assert l_2_error < 1e-5 * N ** 2
+    assert l_1_error < 1e-5 * N ** 3
+

--- a/tests/test_3d/test_backward_3d.py
+++ b/tests/test_3d/test_backward_3d.py
@@ -240,3 +240,51 @@ def test_t2_backward_CPU_points_z(
     inputs = (points_x, points_y, points_z, targets)
 
     assert gradcheck(apply_finufft3d2(fftshift, isign), inputs)
+
+
+
+def check_t2_backward(
+    N: int,
+    modifier: int,
+    fftshift: bool,
+    isign: int,
+    device: str,
+    points_or_targets: bool,
+) -> None:
+    points = torch.rand((3, N + modifier), dtype=torch.float64).to(device) * 2 * np.pi
+    targets = torch.randn(N, N, N, dtype=torch.complex128).to(device)
+
+    points.requires_grad = points_or_targets
+    targets.requires_grad = not points_or_targets
+
+    inputs = (points, targets)
+
+    def func(points, targets):
+        return pytorch_finufft.functional.finufft_type2.apply(
+            points,
+            targets,
+            None,
+            dict(modeord=int(not fftshift), isign=isign),
+        )
+
+    assert gradcheck(func, inputs, atol=1e-5 * N)
+
+
+@pytest.mark.parametrize("N", Ns)
+@pytest.mark.parametrize("modifier", length_modifiers)
+@pytest.mark.parametrize("fftshift", [False, True])
+@pytest.mark.parametrize("isign", [-1, 1])
+def test_t2_backward_CPU_values(
+    N: int, modifier: int, fftshift: bool, isign: int
+) -> None:
+    check_t2_backward(N, modifier, fftshift, isign, "cpu", False)
+
+@pytest.mark.parametrize("N", Ns)
+@pytest.mark.parametrize("modifier", length_modifiers)
+@pytest.mark.parametrize("fftshift", [False, True])
+@pytest.mark.parametrize("isign", [-1, 1])
+def test_t2_backward_CPU_points(
+    N: int, modifier: int, fftshift: bool, isign: int
+) -> None:
+    check_t2_backward(N, modifier, fftshift, isign, "cpu", True)
+

--- a/tests/test_3d/test_backward_3d.py
+++ b/tests/test_3d/test_backward_3d.py
@@ -292,7 +292,7 @@ def test_t2_backward_CPU_points(
 @pytest.mark.parametrize("modifier", length_modifiers)
 @pytest.mark.parametrize("fftshift", [False, True])
 @pytest.mark.parametrize("isign", [-1, 1])
-def test_t2_backward_CPU_values(
+def test_t2_backward_cuda_values(
     N: int, modifier: int, fftshift: bool, isign: int
 ) -> None:
     check_t2_backward(N, modifier, fftshift, isign, "cuda", False)
@@ -301,7 +301,7 @@ def test_t2_backward_CPU_values(
 @pytest.mark.parametrize("modifier", length_modifiers)
 @pytest.mark.parametrize("fftshift", [False, True])
 @pytest.mark.parametrize("isign", [-1, 1])
-def test_t2_backward_CPU_points(
+def test_t2_backward_cuda_points(
     N: int, modifier: int, fftshift: bool, isign: int
 ) -> None:
     check_t2_backward(N, modifier, fftshift, isign, "cuda", True)

--- a/tests/test_3d/test_backward_3d.py
+++ b/tests/test_3d/test_backward_3d.py
@@ -288,3 +288,21 @@ def test_t2_backward_CPU_points(
 ) -> None:
     check_t2_backward(N, modifier, fftshift, isign, "cpu", True)
 
+@pytest.mark.parametrize("N", Ns)
+@pytest.mark.parametrize("modifier", length_modifiers)
+@pytest.mark.parametrize("fftshift", [False, True])
+@pytest.mark.parametrize("isign", [-1, 1])
+def test_t2_backward_CPU_values(
+    N: int, modifier: int, fftshift: bool, isign: int
+) -> None:
+    check_t2_backward(N, modifier, fftshift, isign, "cuda", False)
+
+@pytest.mark.parametrize("N", Ns)
+@pytest.mark.parametrize("modifier", length_modifiers)
+@pytest.mark.parametrize("fftshift", [False, True])
+@pytest.mark.parametrize("isign", [-1, 1])
+def test_t2_backward_CPU_points(
+    N: int, modifier: int, fftshift: bool, isign: int
+) -> None:
+    check_t2_backward(N, modifier, fftshift, isign, "cuda", True)
+

--- a/tests/test_3d/test_forward_3d.py
+++ b/tests/test_3d/test_forward_3d.py
@@ -9,6 +9,7 @@ torch.manual_seed(0)
 
 # Case generation
 Ns = [
+    3,
     5,
     10,
     15,
@@ -92,3 +93,36 @@ def test_3d_t2_forward_CPU(N: int) -> None:
         assert l_inf_error < 1e-5 * N**1.5
         assert l_2_error < 1e-5 * N**3
         assert l_1_error < 1e-5 * N**4.5
+
+
+@pytest.mark.parametrize("N", Ns)
+def test_t2_forward_CPU(N: int) -> None:
+    """
+    Tests against implementations of the FFT by setting up a uniform grid
+    over which to call FINUFFT through the API.
+    """
+    g = np.mgrid[:N, :N, :N] * 2 * np.pi / N
+    points = torch.from_numpy(g.reshape(g.shape[0], -1))
+
+    targets = torch.randn(*g[0].shape, dtype=torch.complex128)
+
+    print("N is " + str(N))
+    print("shape of points is " + str(points.shape))
+    print("shape of targets is " + str(targets.shape))
+
+    finufft_out = pytorch_finufft.functional.finufft_type2.apply(
+        points,
+        targets,
+    )
+
+    against_torch = torch.fft.fftn(targets)
+
+    abs_errors = torch.abs(finufft_out - against_torch.ravel())
+    l_inf_error = abs_errors.max()
+    l_2_error = torch.sqrt(torch.sum(abs_errors**2))
+    l_1_error = torch.sum(abs_errors)
+
+    assert l_inf_error < 4.5e-5 * N ** 1.1
+    assert l_2_error < 6e-5 * N ** 2.1
+    assert l_1_error < 1.2e-4 * N ** 3.2
+


### PR DESCRIPTION
Took a while to figure out but the most natural setting for isign in type 2 is -1, which is also the default in finufft.

TODO:
- [x] add forward tests for 1D and 3D
- [x] implement backward for values (working for 2D)
- [x] implement backward for positions (working for 2D)
- [x] tests for gradients in 2D
- [x] tests for other dimensionalities