### PR TITLE
Automatically skip cuda tests if not available

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,7 +33,7 @@ jobs:
 
     - name: Pytest
       run: |
-        pytest tests/ --cov -k "not cuda"
+        pytest tests/ --cov
 
 
   lint:

--- a/ci/Jenkinsfile
+++ b/ci/Jenkinsfile
@@ -60,7 +60,7 @@ pipeline {
 
       python3 -m pip install -e .[dev] # can make [dev,cuda] once cufinufft released?
 
-      python3 -m pytest -k "cuda" tests/ --cov -v
+      python3 -m pytest -k "cuda" tests/ --cov -v --error-for-skips
     '''
       }
     }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,11 +1,12 @@
-import torch
 import pytest
+import torch
+
 
 # custom: skip tests with 'cuda' in name when unavailable
 def pytest_collection_modifyitems(session, config, items):
     if not torch.cuda.is_available():
         for test in items:
-            if 'cuda' in test.name:
+            if "cuda" in test.name:
                 test.add_marker(pytest.mark.skip("CUDA unavailable"))
 
 
@@ -18,17 +19,19 @@ def pytest_runtest_makereport(item, call):
     outcome = yield
     rep = outcome.get_result()
 
-    if item.config.getoption('--error-for-skips'):
+    if item.config.getoption("--error-for-skips"):
         if rep.skipped and call.excinfo.errisinstance(pytest.skip.Exception):
-            rep.outcome = 'failed'
+            rep.outcome = "failed"
             r = call.excinfo._getreprcrash()
-            rep.longrepr = 'Forbidden skipped test - {message}'.format(message=r.message)
+            rep.longrepr = "Forbidden skipped test - {message}".format(
+                message=r.message
+            )
 
 
 def pytest_addoption(parser):
     parser.addoption(
-        '--error-for-skips',
-        action='store_true',
+        "--error-for-skips",
+        action="store_true",
         default=False,
-        help='Treat skipped tests as errors'
+        help="Treat skipped tests as errors",
     )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,34 @@
+import torch
+import pytest
+
+# custom: skip tests with 'cuda' in name when unavailable
+def pytest_collection_modifyitems(session, config, items):
+    if not torch.cuda.is_available():
+        for test in items:
+            if 'cuda' in test.name:
+                test.add_marker(pytest.mark.skip("CUDA unavailable"))
+
+
+# When we want to explicitly run cuda/fail when cuda is missing,
+# we need to disable skipping.
+# From: https://github.com/jankatins/pytest-error-for-skips
+# See: https://github.com/pytest-dev/pytest/issues/1364
+@pytest.hookimpl(hookwrapper=True)
+def pytest_runtest_makereport(item, call):
+    outcome = yield
+    rep = outcome.get_result()
+
+    if item.config.getoption('--error-for-skips'):
+        if rep.skipped and call.excinfo.errisinstance(pytest.skip.Exception):
+            rep.outcome = 'failed'
+            r = call.excinfo._getreprcrash()
+            rep.longrepr = 'Forbidden skipped test - {message}'.format(message=r.message)
+
+
+def pytest_addoption(parser):
+    parser.addoption(
+        '--error-for-skips',
+        action='store_true',
+        default=False,
+        help='Treat skipped tests as errors'
+    )

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -8,15 +8,14 @@ import pytorch_finufft
 torch.manual_seed(0)
 # devices
 
-
-def test_t1_mismatch_multi_cuda() -> None:
+def test_t1_mismatch_device_cuda_cpu() -> None:
     points = torch.rand((2, 10), dtype=torch.float64)
     values = torch.randn(10, dtype=torch.complex128).to("cuda:0")
 
     with pytest.raises(ValueError, match="Some tensors are not on the same device"):
         pytorch_finufft.functional.finufft_type1.apply(points, values, (10, 10))
 
-
+@pytest.mark.skipif(torch.cuda.device_count() < 2, reason="require multiple GPUs")
 def test_t1_mismatch_cuda_index() -> None:
     points = torch.rand((2, 10), dtype=torch.float64).to("cuda:0")
     values = torch.randn(10, dtype=torch.complex128).to("cuda:1")

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -8,12 +8,14 @@ import pytorch_finufft
 torch.manual_seed(0)
 # devices
 
+
 def test_t1_mismatch_device_cuda_cpu() -> None:
     points = torch.rand((2, 10), dtype=torch.float64)
     values = torch.randn(10, dtype=torch.complex128).to("cuda:0")
 
     with pytest.raises(ValueError, match="Some tensors are not on the same device"):
         pytorch_finufft.functional.finufft_type1.apply(points, values, (10, 10))
+
 
 @pytest.mark.skipif(torch.cuda.device_count() < 2, reason="require multiple GPUs")
 def test_t1_mismatch_cuda_index() -> None:


### PR DESCRIPTION
Uses [pytest_collection_modifyitems](https://docs.pytest.org/en/7.1.x/reference/reference.html#pytest.hookspec.pytest_collection_modifyitems) to disable all the cuda tests if pytorch reports cuda is not available.

Cuda being unavailable in CI is obviously a configuration issue, so it then also adds a command line flag you can pass to turn these skips into errors, which we use for jenkins