### PR TITLE
New pre-commit config to match current linting

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -65,4 +65,3 @@ jobs:
     - name: Lint with mypy
       run: |
         mypy pytorch_finufft/
-

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,43 +1,41 @@
-default_language_version:
-  python: python3.9
-
-default_stages: [commit, push]
-
+# See https://pre-commit.com for more information
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v2.5.0
+    rev: v3.2.0
     hooks:
-      - id: check-yaml
-      - id: end-of-file-fixer
+    -   id: trailing-whitespace
+    -   id: end-of-file-fixer
         exclude: LICENSE
+    -   id: check-yaml
+    -   id: check-added-large-files
 
-  - repo: local
+  - repo: https://github.com/pycqa/isort
+    rev: 5.12.0
     hooks:
-      - id: pyupgrade
-        name: pyupgrade
-        entry: poetry run pyupgrade --py39-plus
-        types: [python]
-        language: system
+      - id: isort
+        name: isort (python)
 
-  - repo: local
+  # Using this mirror lets us use mypyc-compiled black, which is about 2x faster
+  - repo: https://github.com/psf/black-pre-commit-mirror
+    rev: 23.9.1
     hooks:
       - id: black
-        name: black
-        entry: black .
-        types: [python]
-        language: system
-      - id: isort
-        name: isort
-        entry: isort pytorch_finufft/
-        types: [python]
-        language: system
-      - id: ruff
-        name: ruff
-        entry: ruff --format=github --select=E9,F63,F7,F82 --target-version=py39 pytorch_finufft/
-        types: [python]
-        language: system
-      - id: darglint
-        name: darglint
-        entry: darglint -s numpy pytorch_finufft/
-        types: [python]
-        language: system
+
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.0.292
+    hooks:
+        - id: ruff
+
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v1.5.1
+    hooks:
+      - id: mypy
+        exclude: ^tests/|^examples/
+        additional_dependencies:
+          - torch
+          - finufft
+
+
+
+ci:
+  autoupdate_schedule: quarterly

--- a/ci/docker/Dockerfile-cuda11.8
+++ b/ci/docker/Dockerfile-cuda11.8
@@ -55,4 +55,3 @@ RUN yum install -y \
     rm -rf /var/cache/yum/*
 
 ENV PATH /opt/rh/devtoolset-9/root/usr/bin:${PATH}
-


### PR DESCRIPTION
Updates our config for [pre-commit](https://pre-commit.com/) to match the current lints we do in CI.

You can configure this locally by running 
`pip install pre-commit`
`pre-commit install`

After this, each `git commit` will run a series of checks which correspond to the ones we run in our lint action.

You can always skip these if needed by using `git commit --no-verify ...`