### PR TITLE
Clarify dependency version requirements, check for older cufinufft

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -29,6 +29,8 @@ jobs:
           python -m pip install .
 
       - name: Build docs
+        env:
+          SPHINXOPTS: "-v"
         run: |
           cd docs/
           make clean

--- a/README.md
+++ b/README.md
@@ -3,4 +3,6 @@
 Bindings for the Flatiron Institute Nonuniform Fast Fourier Transform ([FINUFFT](https://finufft.readthedocs.io/en/latest/)) library
 in Pytorch.
 
+See the documentation [online](https://flatironinstitute.github.io/pytorch-finufft/).
+
 **Note: this package is currently under active development**

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -6,8 +6,10 @@ Pre-requistes
 -------------
 
 Pytorch-FINUFFT requires either ``finufft`` *and/or* ``cufinufft``
-2.2.0 or greater. Currently, this version is unreleased
-and can only be installed from source. See the relevant pages for
+2.1.0 or greater.
+
+Note that currently, this version of ``cufinufft`` is unreleased
+and can only be installed from source. See the relevant installation pages for
 :external+finufft:doc:`finufft <install>` and
 :external+finufft:doc:`cufinufft <install_gpu>`.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ authors = [
   {name = "Brian Ward", email="bward@flatironinstitute.org"},
 ]
 license = { text = "MIT" }
-dependencies = ["finufft", "torch >= 2", "numpy", "scipy"]
+dependencies = ["finufft>= 2.1", "torch >= 2", "numpy", "scipy"]
 classifiers = [
   "Development Status :: 3 - Alpha",
   "Intended Audience :: Developers",

--- a/pytorch_finufft/functional.py
+++ b/pytorch_finufft/functional.py
@@ -2,6 +2,7 @@
 Implementations of the corresponding Autograd functions
 """
 
+import warnings
 from typing import Any, Callable, Dict, Optional, Tuple, Union
 
 import torch
@@ -16,7 +17,10 @@ except ImportError:
 try:
     import cufinufft
 
-    CUFINUFFT_AVAIL = True
+    if cufinufft.__version__.startswith("1."):
+        warnings.warn("pytorch-finufft does not support cufinufft v1.x.x")
+    else:
+        CUFINUFFT_AVAIL = True
 except ImportError:
     CUFINUFFT_AVAIL = False
 


### PR DESCRIPTION
This does a few small things:

- passes `-v` to the docs build CI to make progress easier to monitor
- links to the documentation in the README
- Clarifies that the currently released finufft is actually fine, its `cufinufft` which is unreleased
- Puts a bound on `finufft`'s version in our project metadata
- Checks for cufinufft's version at runtime and refuses to use 1.x