### PR TITLE
Support batches of values/targets and `torch.vmap`

### DIFF
--- a/ci/Jenkinsfile
+++ b/ci/Jenkinsfile
@@ -60,7 +60,7 @@ pipeline {
 
       python3 -m pip install -e .[dev] # can make [dev,cuda] once cufinufft released?
 
-      python3 -m pytest -k "cuda" tests/ --cov -v --error-for-skips
+      python3 -m pytest -k "cuda" tests/ --cov -v --error-for-skips --durations=20
     '''
       }
     }

--- a/pytorch_finufft/checks.py
+++ b/pytorch_finufft/checks.py
@@ -48,16 +48,20 @@ def check_sizes_t1(values: torch.Tensor, points: torch.Tensor) -> None:
     Checks that values and points are of the same length.
     This is used in type1.
     """
-    if len(values.shape) != 1:
-        raise ValueError("values must be a 1d array")
+    if len(values.shape) not in (1, 2):
+        raise ValueError(
+            "values must be a 1d tensor or a 2d tensor with batch dimension 0"
+        )
+
+    n_values = values.shape[-1]
 
     if len(points.shape) == 1:
-        if len(values) != len(points):
+        if n_values != len(points):
             raise ValueError("The same number of points and values must be supplied")
     elif len(points.shape) == 2:
         if points.shape[0] not in {1, 2, 3}:
             raise ValueError(f"Points can be at most 3d, got {points.shape[0]} instead")
-        if len(values) != points.shape[1]:
+        if n_values != points.shape[1]:
             raise ValueError("The same number of points and values must be supplied")
     else:
         raise ValueError("The points tensor must be 1d or 2d")

--- a/pytorch_finufft/checks.py
+++ b/pytorch_finufft/checks.py
@@ -102,7 +102,8 @@ def check_sizes_t2(targets: torch.Tensor, points: torch.Tensor) -> None:
     if points_dim not in {1, 2, 3}:
         raise ValueError(f"Points can be at most 3d, got {points_dim} instead")
 
-    if targets_dim != points_dim:
+    if targets_dim != points_dim and targets_dim != points_dim + 1:
         raise ValueError(
             f"For type 2 {points_dim}d FINUFFT, targets must be a {points_dim}d tensor"
+            " or a {points_dim + 1}d tensor with batch dimension 0"
         )

--- a/pytorch_finufft/checks.py
+++ b/pytorch_finufft/checks.py
@@ -97,8 +97,8 @@ def check_sizes_t2(targets: torch.Tensor, points: torch.Tensor) -> None:
     if points_dim not in {1, 2, 3}:
         raise ValueError(f"Points can be at most 3d, got {points_dim} instead")
 
-    if targets_dim != points_dim and targets_dim != points_dim + 1:
+    if targets_dim < points_dim:
         raise ValueError(
-            f"For type 2 {points_dim}d FINUFFT, targets must be a {points_dim}d tensor"
-            " or a {points_dim + 1}d tensor with batch dimension 0"
+            f"For type 2 {points_dim}d FINUFFT, targets must be at "
+            f"least a {points_dim}d tensor"
         )

--- a/pytorch_finufft/checks.py
+++ b/pytorch_finufft/checks.py
@@ -48,11 +48,6 @@ def check_sizes_t1(values: torch.Tensor, points: torch.Tensor) -> None:
     Checks that values and points are of the same length.
     This is used in type1.
     """
-    if len(values.shape) not in (1, 2):
-        raise ValueError(
-            "values must be a 1d tensor or a 2d tensor with batch dimension 0"
-        )
-
     n_values = values.shape[-1]
 
     if len(points.shape) == 1:

--- a/pytorch_finufft/functional.py
+++ b/pytorch_finufft/functional.py
@@ -149,18 +149,32 @@ class FinufftType1(torch.autograd.Function):
         if batch_points is not None:
             # need a for-loop here
             points = points.movedim(batch_points, 0)
-            output = torch.stack(
-                [
-                    FinufftType1.apply(
-                        points[i],
-                        values,
-                        output_shape,
-                        finufftkwargs,
-                    )
-                    for i in range(points.shape[0])
-                ],
-                dim=0,
-            )
+            if batch_values is not None:
+                output = torch.stack(
+                    [
+                        FinufftType1.apply(
+                            points[i],
+                            values[i],
+                            output_shape,
+                            finufftkwargs,
+                        )
+                        for i in range(points.shape[0])
+                    ],
+                    dim=0,
+                )
+            else:
+                output = torch.stack(
+                    [
+                        FinufftType1.apply(
+                            points[i],
+                            values,
+                            output_shape,
+                            finufftkwargs,
+                        )
+                        for i in range(points.shape[0])
+                    ],
+                    dim=0,
+                )
         else:
             output = FinufftType1.apply(points, values, output_shape, finufftkwargs)
 
@@ -356,17 +370,30 @@ class FinufftType2(torch.autograd.Function):
         if batch_points is not None:
             # need a for-loop here
             points = points.movedim(batch_points, 0)
-            output = torch.stack(
-                [
-                    FinufftType2.apply(
-                        points[i],
-                        targets,
-                        finufftkwargs,
-                    )
-                    for i in range(points.shape[0])
-                ],
-                dim=0,
-            )
+            if batch_targets is not None:
+                output = torch.stack(
+                    [
+                        FinufftType2.apply(
+                            points[i],
+                            targets[i],  # inner product
+                            finufftkwargs,
+                        )
+                        for i in range(points.shape[0])
+                    ],
+                    dim=0,
+                )
+            else:
+                output = torch.stack(
+                    [
+                        FinufftType2.apply(
+                            points[i],
+                            targets,
+                            finufftkwargs,
+                        )
+                        for i in range(points.shape[0])
+                    ],
+                    dim=0,
+                )
         else:
             output = FinufftType2.apply(points, targets, finufftkwargs)
 

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -267,7 +267,7 @@ def test_t2_mismatch_dims() -> None:
     targets = torch.randn(*g[0].shape[:-1], dtype=torch.complex128)
 
     with pytest.raises(
-        ValueError, match="For type 2 3d FINUFFT, targets must be a 3d tensor"
+        ValueError, match="For type 2 3d FINUFFT, targets must be at least a 3d tensor"
     ):
         pytorch_finufft.functional.finufft_type2(points, targets)
 

--- a/tests/test_t1_backward.py
+++ b/tests/test_t1_backward.py
@@ -7,7 +7,6 @@ from torch.autograd import gradcheck
 
 import pytorch_finufft
 
-torch.set_default_tensor_type(torch.DoubleTensor)
 torch.set_default_dtype(torch.float64)
 torch.manual_seed(1234)
 

--- a/tests/test_t1_batch.py
+++ b/tests/test_t1_batch.py
@@ -1,0 +1,188 @@
+from typing import Any, Callable, Tuple, Union
+
+import numpy as np
+import pytest
+import torch
+from torch.autograd import gradcheck
+
+import pytorch_finufft
+
+torch.random.manual_seed(1234)
+
+
+def check_t1_batched_targets(
+    F: Callable[..., Any],
+    N: int,
+    batchsize: Union[int, Tuple[int, ...]],
+    dim: int,
+    device: str,
+) -> None:
+    if not isinstance(batchsize, tuple):
+        batchsize = (batchsize,)
+
+    slices = tuple(slice(None, N) for _ in range(dim))
+    g = np.mgrid[slices] * 2 * np.pi / N
+    points = torch.from_numpy(g.reshape(dim, -1)).to(device)
+
+    values = torch.randn(*batchsize, *points[0].shape, dtype=torch.complex128).to(
+        device
+    )
+
+    print("N is " + str(N))
+    print("dim is " + str(dim))
+    print("shape of points is " + str(points.shape))
+    print("shape of values is " + str(values.shape))
+
+    output_shape = tuple(N for _ in range(dim))
+
+    finufft_out = F(
+        points,
+        values,
+        output_shape,
+    )
+
+    against_torch = torch.fft.fftn(
+        values.reshape(*batchsize, *g[0].shape), dim=tuple(range(-dim, 0))
+    )
+
+    abs_errors = torch.abs(finufft_out - against_torch.reshape(finufft_out.shape))
+    l_inf_error = abs_errors.max()
+    l_2_error = torch.sqrt(torch.sum(abs_errors**2))
+    l_1_error = torch.sum(abs_errors)
+
+    assert l_inf_error < 4.5e-5 * N**1.1
+    assert l_2_error < 6e-5 * N**2.1
+    assert l_1_error < 1.2e-4 * N**3.2
+
+    points.requires_grad = True
+    values.requires_grad = True
+
+    def f(p, v):
+        return F(p, v, output_shape)
+
+    gradcheck(f, (points, values), eps=1e-8, atol=2e-4)
+
+
+values_cases = [
+    (2, 1, 1),  # check that batch of 1 is happy
+    (2, (2, 3), 1),
+    (2, 2, 2),
+    (2, (2, 1, 3), 3),
+]
+
+
+@pytest.mark.parametrize("N, batch, dim", values_cases)
+def test_t1_batching_CPU(N, batch, dim):
+    check_t1_batched_targets(
+        pytorch_finufft.functional.finufft_type1, N, batch, dim, "cpu"
+    )
+
+
+@pytest.mark.parametrize("N, batch, dim", values_cases)
+def test_t1_batching_cuda(N, batch, dim):
+    check_t1_batched_targets(
+        pytorch_finufft.functional.finufft_type1, N, batch, dim, "cuda"
+    )
+
+
+def batch_vmapped(batch: Union[int, Tuple[int, ...]]) -> Callable[..., Any]:
+    if not isinstance(batch, tuple):
+        batch = (batch,)
+
+    F = pytorch_finufft.functional.finufft_type1
+    for _ in batch:
+        F = torch.vmap(F, in_dims=(None, 0, None), out_dims=0)
+    return F
+
+
+@pytest.mark.parametrize("N, batch, dim", values_cases)
+def test_t1_vmap_targets_CPU(N, batch, dim):
+    check_t1_batched_targets(batch_vmapped(batch), N, batch, dim, "cpu")
+
+
+@pytest.mark.parametrize("N, batch, dim", values_cases)
+def test_t1_vmap_targets_cuda(N, batch, dim):
+    check_t1_batched_targets(batch_vmapped(batch), N, batch, dim, "cuda")
+
+
+# because points are not natively batchable in finufft, we only test vmap
+def check_t1_vmapped_points(
+    N: int,
+    values_batchsize: Union[int, Tuple],
+    dim: int,
+    device: str,
+):
+    if not isinstance(values_batchsize, tuple):
+        values_batchsize = (values_batchsize,)
+
+    slices = tuple(slice(None, N) for _ in range(dim))
+    g = np.mgrid[slices] * 2 * np.pi / N
+    points = torch.from_numpy(g.reshape(dim, -1)).to(device)
+
+    values = torch.randn(
+        *values_batchsize, *points[0].shape, dtype=torch.complex128
+    ).to(device)
+    points = torch.stack(
+        (points, points + 0.02), dim=0
+    )  # slight perturbation to check that vmap is working
+
+    print("N is " + str(N))
+    print("dim is " + str(dim))
+    print("shape of points is " + str(points.shape))
+    print("shape of values is " + str(values.shape))
+
+    output_shape = tuple(N for _ in range(dim))
+
+    F = torch.vmap(
+        pytorch_finufft.functional.finufft_type1,
+        in_dims=(0, 0 if values_batchsize else None, None),
+        out_dims=0,
+    )
+
+    finufft_out = F(
+        points,
+        values,
+        output_shape,
+    )
+
+    against_torch = torch.fft.fftn(
+        values.reshape(*values_batchsize, *g[0].shape), dim=tuple(range(-dim, 0))
+    )
+    if values_batchsize:
+        against_torch = against_torch[0]
+    abs_errors = torch.abs(finufft_out[0].ravel() - against_torch.ravel())
+    l_inf_error = abs_errors.max()
+    l_2_error = torch.sqrt(torch.sum(abs_errors**2))
+    l_1_error = torch.sum(abs_errors)
+
+    assert l_inf_error < 4.5e-5 * N**1.1
+    assert l_2_error < 6e-5 * N**2.1
+    assert l_1_error < 1.2e-4 * N**3.2
+
+    points.requires_grad = True
+    values.requires_grad = True
+
+    def f(p, v):
+        return F(p, v, output_shape)
+
+    gradcheck(f, (points, values), eps=1e-8, atol=2e-4)
+
+
+points_cases = [
+    (2, (), 1),
+    (2, (), 2),
+    (2, (), 3),
+    (2, (2,), 1),
+    (2, (2,), 2),
+    (2, (2,), 3),
+]
+
+
+@pytest.mark.parametrize("N, batch, dim", points_cases)
+def test_t1_vmap_points_CPU(N, batch, dim):
+    check_t1_vmapped_points(N, batch, dim, "cpu")
+
+
+@pytest.mark.parametrize("N, batch, dim", points_cases)
+def test_t1_vmap_points_cuda(N, batch, dim):
+    check_t1_vmapped_points(N, batch, dim, "cuda")

--- a/tests/test_t2_backward.py
+++ b/tests/test_t2_backward.py
@@ -7,7 +7,6 @@ from torch.autograd import gradcheck
 
 import pytorch_finufft
 
-torch.set_default_tensor_type(torch.DoubleTensor)
 torch.set_default_dtype(torch.float64)
 torch.manual_seed(1234)
 

--- a/tests/test_t2_batch.py
+++ b/tests/test_t2_batch.py
@@ -1,0 +1,171 @@
+from typing import Any, Callable, Tuple, Union
+
+import numpy as np
+import pytest
+import torch
+from torch.autograd import gradcheck
+
+import pytorch_finufft
+
+torch.random.manual_seed(1234)
+
+
+def check_t2_batched_targets(
+    F: Callable[..., Any],
+    N: int,
+    batchsize: Union[int, Tuple[int, ...]],
+    dim: int,
+    device: str,
+) -> None:
+    if not isinstance(batchsize, tuple):
+        batchsize = (batchsize,)
+
+    slices = tuple(slice(None, N) for _ in range(dim))
+    g = np.mgrid[slices] * 2 * np.pi / N
+    points = torch.from_numpy(g.reshape(g.shape[0], -1)).to(device)
+
+    targets = torch.randn(*batchsize, *g[0].shape, dtype=torch.complex128).to(device)
+
+    print("N is " + str(N))
+    print("dim is " + str(dim))
+    print("shape of points is " + str(points.shape))
+    print("shape of targets is " + str(targets.shape))
+
+    finufft_out = F(
+        points,
+        targets,
+    )
+
+    against_torch = torch.fft.fftn(targets, dim=tuple(range(-dim, 0)))
+
+    abs_errors = torch.abs(finufft_out - against_torch.reshape(finufft_out.shape))
+    l_inf_error = abs_errors.max()
+    l_2_error = torch.sqrt(torch.sum(abs_errors**2))
+    l_1_error = torch.sum(abs_errors)
+
+    assert l_inf_error < 4.5e-5 * N**1.1
+    assert l_2_error < 6e-5 * N**2.1
+    assert l_1_error < 1.2e-4 * N**3.2
+
+    points.requires_grad = True
+    targets.requires_grad = True
+
+    gradcheck(F, (points, targets), eps=1e-8, atol=2e-4)
+
+
+targets_cases = [
+    (2, 1, 1),  # check that batch of 1 is happy
+    (2, (2, 3), 1),
+    (2, 2, 2),
+    (2, (2, 1, 3), 3),
+]
+
+
+@pytest.mark.parametrize("N, batch, dim", targets_cases)
+def test_t2_batching_CPU(N, batch, dim):
+    check_t2_batched_targets(
+        pytorch_finufft.functional.finufft_type2, N, batch, dim, "cpu"
+    )
+
+
+@pytest.mark.parametrize("N, batch, dim", targets_cases)
+def test_t2_batching_cuda(N, batch, dim):
+    check_t2_batched_targets(
+        pytorch_finufft.functional.finufft_type2, N, batch, dim, "cuda"
+    )
+
+
+def batch_vmapped(batch: Union[int, Tuple[int, ...]]) -> Callable[..., Any]:
+    if not isinstance(batch, tuple):
+        batch = (batch,)
+
+    F = pytorch_finufft.functional.finufft_type2
+    for _ in batch:
+        F = torch.vmap(F, in_dims=(None, 0), out_dims=0)
+    return F
+
+
+@pytest.mark.parametrize("N, batch, dim", targets_cases)
+def test_t2_vmap_targets_CPU(N, batch, dim):
+    check_t2_batched_targets(batch_vmapped(batch), N, batch, dim, "cpu")
+
+
+@pytest.mark.parametrize("N, batch, dim", targets_cases)
+def test_t2_vmap_targets_cuda(N, batch, dim):
+    check_t2_batched_targets(batch_vmapped(batch), N, batch, dim, "cuda")
+
+
+# because points are not natively batchable in finufft, we only test vmap
+def check_t2_vmapped_points(
+    N: int,
+    targets_batchsize: Union[int, Tuple],
+    dim: int,
+    device: str,
+):
+    if not isinstance(targets_batchsize, tuple):
+        targets_batchsize = (targets_batchsize,)
+
+    slices = tuple(slice(None, N) for _ in range(dim))
+    g = np.mgrid[slices] * 2 * np.pi / N
+    points = torch.from_numpy(g.reshape(g.shape[0], -1)).to(device)
+
+    targets = torch.randn(*targets_batchsize, *g[0].shape, dtype=torch.complex128).to(
+        device
+    )
+    points = torch.stack(
+        (points, points + 0.02), dim=0
+    )  # slight perturbation to check that vmap is working
+
+    print("N is " + str(N))
+    print("dim is " + str(dim))
+    print("shape of points is " + str(points.shape))
+    print("shape of targets is " + str(targets.shape))
+
+    F = torch.vmap(
+        pytorch_finufft.functional.finufft_type2,
+        in_dims=(0, 0 if targets_batchsize else None),
+        out_dims=0,
+    )
+
+    finufft_out = F(
+        points,
+        targets,
+    )
+
+    against_torch = torch.fft.fftn(targets, dim=tuple(range(-dim, 0)))
+
+    if targets_batchsize:
+        against_torch = against_torch[0]
+    abs_errors = torch.abs(finufft_out[0].ravel() - against_torch.ravel())
+    l_inf_error = abs_errors.max()
+    l_2_error = torch.sqrt(torch.sum(abs_errors**2))
+    l_1_error = torch.sum(abs_errors)
+
+    assert l_inf_error < 4.5e-5 * N**1.1
+    assert l_2_error < 6e-5 * N**2.1
+    assert l_1_error < 1.2e-4 * N**3.2
+
+    points.requires_grad = True
+    targets.requires_grad = True
+
+    gradcheck(F, (points, targets), eps=1e-8, atol=2e-4)
+
+
+points_cases = [
+    (2, (), 1),
+    (2, (), 2),
+    (2, (), 3),
+    (2, (2,), 1),
+    (2, (2,), 2),
+    (2, (2,), 3),
+]
+
+
+@pytest.mark.parametrize("N, batch, dim", points_cases)
+def test_t2_vmap_points_CPU(N, batch, dim):
+    check_t2_vmapped_points(N, batch, dim, "cpu")
+
+
+@pytest.mark.parametrize("N, batch, dim", points_cases)
+def test_t2_vmap_points_cuda(N, batch, dim):
+    check_t2_vmapped_points(N, batch, dim, "cuda")


### PR DESCRIPTION
This PR does three things:

First, it removes `ctx` from `forward()` in favor of using `setup_ctx`. This does duplicate some argument munging, but it's not too bad.

The meat of the changes are allowing the `values` argument for t1 and `targets` argument for t2 to have arbitrary leading batch dimensions. These are properly shaped down to the 1 dimensional batching FINUFFT supports, and then reshaped back out to the batching dimensions. Forward and backward support this.

Once this was implemented, supporting `torch.vmap` was pretty simple: if we're vmapping targets/values, we just need to make sure the vmap'd dimension comes before the others. If we're vmapping points, we implement that as a simple for-loop for now, since FINUFFT doesn't support batching points. We may be able to speed this up/make it async using CUDA streams, later.

Some minimal tests are added for forward and backward of both the vmap version and the normal batching.

Closes #63 
Closes #95 